### PR TITLE
Add missing Sphinx param type

### DIFF
--- a/adafruit_adxl37x.py
+++ b/adafruit_adxl37x.py
@@ -69,7 +69,7 @@ class ADXL375(adafruit_adxl34x.ADXL345):
     Driver for the ADXL375 accelerometer
 
     :param ~busio.I2C i2c: The I2C bus the ADXL375 is connected to.
-    :param address: The I2C device address for the sensor. Default is :const:`0x53`.
+    :param int address: The I2C device address for the sensor. Default is :const:`0x53`.
 
     **Quickstart: Importing and using the device**
 


### PR DESCRIPTION
Minor update for a missing parameter type I happened to notice in the RTD documentation