### PR TITLE
fix readme circup instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install adxl37x
+    circup install adafruit_adxl37x
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
Resolves the following issue for this library: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/issues/407 for this library

Editted by: tekktrik (removing auto-linking issue)